### PR TITLE
Fix Fabric Demoireing links

### DIFF
--- a/ECCV2026.md
+++ b/ECCV2026.md
@@ -303,8 +303,8 @@ ECCV完整论文库：https://www.ecva.net/papers.php
 # 15.图像去摩尔纹(Image Demoireing)
 
 ### Fabric Image Demoiréing Benchmark from Synthesis to Restoration
-- Paper:
-- Code: https://github.com/Running-Turtle1/PRISM-page
+- Paper: https://arxiv.org/abs/2606.24072
+- Code: https://github.com/Running-Turtle1/Fabric-Demoireing
 
 ### Freqformer: Image-Demoiréing Transformer via Efficient Frequency Decomposition
 - Paper: https://arxiv.org/abs/2505.19120
@@ -392,7 +392,6 @@ ECCV完整论文库：https://www.ecva.net/papers.php
 - Code: https://github.com/MmelodYy/UniStitch
 
 <font color=red size=5>持续更新~</font>
-
 
 
 


### PR DESCRIPTION
Adds the arXiv link for Fabric Image Demoiréing Benchmark from Synthesis to Restoration and updates the code link to the Fabric-Demoireing repository.